### PR TITLE
fix issue template for the new GH flow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,12 @@
+---
+name: Bug report
+about: meow
+title: ''
+labels: ''
+assignees: ''
+
+---
+
 URL:
 ```
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0941cc13-6048-4143-b67a-fddd3a1c03cf)

so apparently github deprecated the old issue template system, and they only display a warning about it now (i.e. when creating a new issue, the template doesn't get prefilled like it should).

this is the minimal amount of Stuff needed to make the new system work. hope this is helpful :)

contribution licensed under whatever you want. Public Domain.